### PR TITLE
Add note about CSRF token error in DDEV

### DIFF
--- a/pages/04.knowledgebase/06.development/how-to-install-mautic-using-ddev/default.md
+++ b/pages/04.knowledgebase/06.development/how-to-install-mautic-using-ddev/default.md
@@ -77,6 +77,8 @@ If this is your first DDEV instance this can take a bit of time to initialise, a
 
 Once started you will find your project at mautic.ddev.site (in case you used a different project name it will be yourprojectname.ddev.site). If you want to enable HTTPS, you can do so by following the steps in [Using DDEV with HTTPS](#using-ddev-with-https) below.
 
+>>>>> Note: if you get an error in the installation process "The CSRF token is invalid", please make sure to use `https://` in front of your Mautic URL.
+
 Navigating to mautic.ddev.site in your browser should bring up the Mautic installation steps. Make sure that during the installation you use the following settings:
 ```
 Database port: 3306


### PR DESCRIPTION
As reported by @RCheesley, switching to `https://` fixed it

![image](https://user-images.githubusercontent.com/17739158/104915536-1311dd80-5991-11eb-876d-2b38664485b6.png)
